### PR TITLE
Fix OSX sed compatability

### DIFF
--- a/desk
+++ b/desk
@@ -136,7 +136,7 @@ get_callables() {
     local DESKPATH=$1
     grep -E "^(alias |(function )?[a-zA-Z0-9_]+\()" "$DESKPATH" \
         | sed 's/alias \([^= ]*\)=.*/\1/' \
-        | sed 's/\(function \)\?\([a-zA-Z0-9]*\)().*/\2/'
+        | sed -E 's/(function )?([a-zA-Z0-9]*)\(\).*/\2/'
 }
 
 


### PR DESCRIPTION
I am not a sed expert but this seems to fix #7 for me on OSX.  I don't have a linux machine to test on until this evening, but it seems to work whether I use gnu sed or bsd sed on OSX.