### PR TITLE
Added some default/standard targets on the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
 
+.PHONY: default
+default:
+	@echo "Desk doesn't need to be compiled. Please run \"sudo make install\" to install desk." ||:
+
+.PHONY: install
+install:
+	@cp ./desk /usr/bin/desk ||:
+	@echo "Installing desk to /usr/bin/desk" ||:
+
+.PHONY: uninstall
+uninstall:
+	@rm /usr/bin/desk ||:
+	@echo "Removing desk from /usr/bin" ||:
+
 .PHONY: dockerbuild
 dockerbuild:
 	docker build -t desk/desk .

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 
 .PHONY: default
 default:
-	@echo "Desk doesn't need to be compiled. Please run \"sudo make install\" to install desk." ||:
+	@echo "Desk doesn't need to be compiled. Please run \"sudo make install\" to install desk."
 
 .PHONY: install
 install:
 	@cp ./desk /usr/bin/desk ||:
-	@echo "Installing desk to /usr/bin/desk" ||:
+	@echo "Installing desk to /usr/bin/desk"
 
 .PHONY: uninstall
 uninstall:
 	@rm /usr/bin/desk ||:
-	@echo "Removing desk from /usr/bin" ||:
+	@echo "Removing desk from /usr/bin"
 
 .PHONY: dockerbuild
 dockerbuild:


### PR DESCRIPTION
Hey James,

Your instructions on the master branch:

>Installing

>1. `git clone git@github.com:jamesob/desk.git && cd desk`
>2. `sudo make install` or `cp desk ~/bin/desk`

Are outdated/incorrect. Definitely a nitpick, but there's no "make install" target in the Makefile, so I added a default target that notifies the user that desk has no compilation, as well as install/uninstall targets. 