### PR TITLE
Fix get_running_shell on Mac OS X

### DIFF
--- a/desk
+++ b/desk
@@ -166,15 +166,19 @@ get_callables() {
 
 # Echo the name of the parent shell via procfs, if we have it available.
 get_running_shell() {
-    # Get cmdline procfile of the process running this script.
-    local CMDLINE_FILE="/proc/$(grep PPid /proc/$$/status | cut -f2)/cmdline"
+    if [ -e /proc ]; then
+        # Get cmdline procfile of the process running this script.
+        local CMDLINE_FILE="/proc/$(grep PPid /proc/$$/status | cut -f2)/cmdline"
 
-    if [ -f "$CMDLINE_FILE" ]; then
-        # Strip out any verion that may be attached to the shell executable.
-        local CMDLINE_SHELL=$(sed -r -e 's/\x0.*//' "$CMDLINE_FILE")
-        basename "$CMDLINE_SHELL"
+        if [ -f "$CMDLINE_FILE" ]; then
+            # Strip out any verion that may be attached to the shell executable.
+            local CMDLINE_SHELL=$(sed -r -e 's/\x0.*//' "$CMDLINE_FILE")
+            basename "$CMDLINE_SHELL"
+            exit
+        fi
     else
-        echo "$SHELL"
+        basename "$SHELL"
+        exit
     fi
 }
 

--- a/desk
+++ b/desk
@@ -164,8 +164,8 @@ get_callables() {
         | sed -E "s/function (${FNAME_CHARS}+).*/\1/"
 }
 
-# Echo the name of the parent shell via procfs, if we have it available.
 get_running_shell() {
+    # Echo the name of the parent shell via procfs, if we have it available.
     if [ -e /proc ]; then
         # Get cmdline procfile of the process running this script.
         local CMDLINE_FILE="/proc/$(grep PPid /proc/$$/status | cut -f2)/cmdline"
@@ -176,10 +176,11 @@ get_running_shell() {
             basename "$CMDLINE_SHELL"
             exit
         fi
-    else
-        basename "$SHELL"
-        exit
     fi
+    
+    # Fall back to $SHELL otherwise.
+    basename "$SHELL"
+    exit
 }
 
 # Echo the extension of recognized deskfiles (.fish for fish)


### PR DESCRIPTION
- Mac OS X doesn't have /proc; change code so that no errors are printed to stderr
- $SHELL may actually by a full path like /usr/bin/bash, use `basename` to get the actual shell name