### PR TITLE
Allow spaces between function names and parens

### DIFF
--- a/desk
+++ b/desk
@@ -133,7 +133,7 @@ cmd_current() {
             # Last clause in the grep regexp accounts for fish functions.
             local DOCLINE=$(
                 grep -B 1 -E \
-                    "^(alias ${NAME}=|(function )?${NAME}\()|function $NAME" "$DESKPATH" \
+                    "^(alias ${NAME}=|(function )?${NAME}( )?\()|function $NAME" "$DESKPATH" \
                     | grep "#")
 
             if [ -z "$DOCLINE" ]; then
@@ -158,9 +158,9 @@ echo_description() {
 # Echo a list of aliases and functions for a given desk
 get_callables() {
     local DESKPATH=$1
-    grep -E "^(alias |(function )?${FNAME_CHARS}+\()|function $NAME" "$DESKPATH" \
+    grep -E "^(alias |(function )?${FNAME_CHARS}+ ?\()|function $NAME" "$DESKPATH" \
         | sed 's/alias \([^= ]*\)=.*/\1/' \
-        | sed -E "s/(function )?(${FNAME_CHARS}+)\(\).*/\2/" \
+        | sed -E "s/(function )?(${FNAME_CHARS}+) ?\(\).*/\2/" \
         | sed -E "s/function (${FNAME_CHARS}+).*/\1/"
 }
 

--- a/examples/terraform.sh
+++ b/examples/terraform.sh
@@ -18,14 +18,14 @@ plan() {
 }
 
 # Run `terraform apply` with proper AWS var config
-apply() {
+apply () {
   terraform apply \
     -var "access_key=${AWS_ACCESS_KEY_ID}" \
     -var "secret_key=${AWS_SECRET_ACCESS_KEY}"
 }
 
 # Set up terraform config: <config_key>
-config() {
+config () {
   local KEY=$1
   terraform remote config -backend=s3 \
     -backend-config="bucket=some.bucket.secrets.terraform" \


### PR DESCRIPTION
Allow function declaration like
```sh
foo () {
  echo bar
}
```

Thanks to @mblarsen for spotting this one.