### PR TITLE
Allow desk activation without arguments

### DIFF
--- a/desk
+++ b/desk
@@ -25,7 +25,7 @@ Usage:
         Initialize desk configuration.
     $PROGRAM (list|ls)
         List all desks along with a description.
-    $PROGRAM (.|go) desk-name
+    $PROGRAM [.|go] desk-name
         Activate a desk.
     $PROGRAM help
         Show this text.
@@ -201,6 +201,7 @@ case "$1" in
     version|--version) shift;  cmd_version "$@" ;;
     ls|list) shift;            cmd_list "$@" ;;
     go|.) shift;               cmd_go "$@" ;;
-    *)                         cmd_current "$@" ;;
+    "")                        cmd_current ;;
+    *)                         cmd_go "$@" ;;
 esac
 exit 0

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -20,7 +20,7 @@ echo $HELP | grep 'desk init' >/dev/null
 ensure $? "Desk help doesn't contain init"
 echo $HELP | grep 'desk (list|ls)' >/dev/null
 ensure $? "Desk help doesn't contain list"
-echo $HELP | grep 'desk (.|go)' >/dev/null
+echo $HELP | grep 'desk \[.|go\]' >/dev/null
 ensure $? "Desk help doesn't contain go"
 echo $HELP | grep 'desk help' >/dev/null
 ensure $? "Desk help doesn't contain help"


### PR DESCRIPTION
This allows to activate a desk with:

    desk <deskname>

as long as it does not collidate with built-in command (like ls). It also
keeps the behaviour to show the active desk without any argument.