### PR TITLE
Add zsh framework plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ rendering.
 
 ### Installing
 
+#### Manually
 0. `curl https://raw.githubusercontent.com/jamesob/desk/master/desk > ~/bin/desk`
 0. `less ~/bin/desk` to make sure you've downloaded what you think you've downloaded.
 0. `chmod +x ~/bin/desk`
@@ -108,6 +109,23 @@ rendering.
 Note that `~/bin` may not exist on your system, or may not be on your PATH. Feel free
 to substitute that for another directory, e.g. `/usr/local/bin`, and add `sudo` as
 necessary.
+
+#### Using [Antigen](https://github.com/zsh-users/antigen)
+
+0. Add `antigen bundle jamesob/desk` to your `.zshrc`
+0. Open a new terminal window. Antigen will clone the desk repo and add it to your path.
+
+#### Using [oh-my-zsh](http://ohmyz.sh/)
+
+0. `cd ~/.oh-my-zsh/custom/plugins`
+0. `git clone git@github.com:jamesob/desk.git`
+0. Add desk to your plugin list
+
+#### Using [zgen](https://github.com/tarjoilija/zgen)
+
+0. Add `zgen load jamesob/desk` to your `.zshrc` with your other load commands
+0. `rm ~/.zgen/init.zsh`
+0. Start a new shell; zgen will generate a new `init.zsh` and automatically clone the desk repository for you and add it to your path.
 
 ### Deskfile rules
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![build](https://api.travis-ci.org/jamesob/desk.svg?branch=master)](https://travis-ci.org/jamesob/desk) [![Join the chat at https://gitter.im/jamesob/desk](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jamesob/desk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Lightweight workspace manager for the shell. 
+Lightweight workspace manager for the shell.
 
 Desk makes it easy to flip back and forth between different project contexts in
 your favorite shell. Change directory, activate a virtualenv or rvm, load
@@ -18,7 +18,7 @@ desk.
 I have a hard time calling this a "workspace manager" with a straight
 face -- it's basically just a shell script that sources another shell script in a new shell.
 But I often find myself working in multiple different code trees simultaneously:
-the quick context switches and namespaced commands that desk facilitates 
+the quick context switches and namespaced commands that desk facilitates
 have proven useful.
 
 There are no dependencies other than `bash`. Desk is explicitly tested with `bash`,
@@ -30,7 +30,7 @@ There are no dependencies other than `bash`. Desk is explicitly tested with `bas
 Usage:
 
     desk
-        List the current desk and any associated aliases. If no desk 
+        List the current desk and any associated aliases. If no desk
         is being used, display available desks.
     desk init
         Initialize desk configuration.
@@ -39,7 +39,7 @@ Usage:
     desk (.|go) desk-name
         Activate a desk.
     desk edit [desk-name]
-        Edit (or create) a deskfile with the name specified, otherwise 
+        Edit (or create) a deskfile with the name specified, otherwise
         edit the active deskfile.
     desk help
         Show this text.
@@ -55,7 +55,7 @@ simply need to exit or otherwise end the current shell process.
 For example, given this deskfile (`~/.desk/desks/tf.sh`):
 ```sh
 # tf.sh
-# 
+#
 # Description: desk for doing work on a terraform-based repository
 #
 
@@ -73,12 +73,12 @@ plan() {
     -var "access_key=${AWS_ACCESS_KEY_ID}" \
     -var "secret_key=${AWS_SECRET_ACCESS_KEY}"
 }
- 
+
 # Run `terraform apply` with proper AWS var config
 alias apply='terraform apply'
 ```
 
-we'd get 
+we'd get
 
 ```sh
 $ desk . tf
@@ -91,12 +91,12 @@ desk for doing work on a terraform repo
   plan - Run `terraform plan` with proper AWS var config
   apply - Run `terraform apply` with proper AWS var config
 ```
- 
+
 Basically, desk just associates a shell script (`name.sh`) with a name. When
 you call `desk . name`, desk drops you into a shell where `name.sh` has been
 executed, and then desk extracts out certain comments in `name.sh` for useful
 rendering.
-          
+
 ### Installing
 
 0. `curl https://raw.githubusercontent.com/jamesob/desk/master/desk > ~/bin/desk`
@@ -106,18 +106,18 @@ rendering.
 0. Start adding deskfiles to your config directory, e.g. `~/.desk/desks/hacking_gibson.sh`
 
 Note that `~/bin` may not exist on your system, or may not be on your PATH. Feel free
-to substitute that for another directory, e.g. `/usr/local/bin`, and add `sudo` as 
+to substitute that for another directory, e.g. `/usr/local/bin`, and add `sudo` as
 necessary.
 
 ### Deskfile rules
 
-Deskfiles are just shell scripts, nothing more, that live in the desk config directory. 
+Deskfiles are just shell scripts, nothing more, that live in the desk config directory.
 Desk does pay attention to certain kinds of comments, though.
 
 - *description*: you can describe a deskfile by including `# Description: ...`
   somewhere in the file.
 
-- *alias and function docs*: if the line above an alias or function is a 
+- *alias and function docs*: if the line above an alias or function is a
   comment, it will be used as documentation.
 
 ### Sharing deskfiles across computers
@@ -137,9 +137,9 @@ and/or `$DESK_DESKS_DIR` to match in your shell's rc file.
 
 Desk won't work when used strictly with `~/.bash_profile` on OS X's terminal, since
 the content of `~/.bash_profile` is only executed on *login*, not shell creation, as
-explained [here](http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html). 
+explained [here](http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html).
 
-My recommendation is to use `~/.bashrc` as your general-purpose config file, then simply 
+My recommendation is to use `~/.bashrc` as your general-purpose config file, then simply
 have `~/.bash_profile` point to it:
 ```sh
 # ~/.bash_profile

--- a/completions/_desk
+++ b/completions/_desk
@@ -1,0 +1,21 @@
+#compdef desk
+_desk() {
+  local -a commands
+  commands=(
+    'help:Print a help message.'
+    'init:Initialize your desk configuration.'
+    'list:List available desks'
+    'ls:List available desks'
+    'edit:Edit or create a desk, defaults to current desk'
+    'go:activate a desk'
+    'version:Dhow the desk version.'
+  )
+
+  if (( CURRENT == 2 )); then
+    _describe -t commands 'commands' commands
+  fi
+
+  return 0
+}
+
+_desk

--- a/completions/_desk
+++ b/completions/_desk
@@ -7,8 +7,9 @@ _desk() {
     'list:List available desks'
     'ls:List available desks'
     'edit:Edit or create a desk, defaults to current desk'
-    'go:activate a desk'
-    'version:Dhow the desk version.'
+    'go:Activate a desk'
+    '.:Activate a desk'
+    'version:Show the desk version.'
   )
 
   if (( CURRENT == 2 )); then

--- a/desk.plugin.zsh
+++ b/desk.plugin.zsh
@@ -1,0 +1,7 @@
+# Make desk easier to use with ZSH frameworks.
+# Add our plugin's bin diretory to user's path
+PLUGIN_D="$(dirname $0)"
+export PATH=${PATH}:${PLUGIN_D}
+
+# Make our completion file available
+export FPATH=${FPATH}:${PLUGIN_D}/completions


### PR DESCRIPTION
* Added a ZSH completion function for the **desk** command
* Added a plugin.zsh file. This will allow frameworks like [Antigen](https://github.com/zsh-users/antigen), [oh-my-zsh](http://ohmyz.sh/), and [zgen](https://github.com/tarjoilija/zgen) to automatically clone the repository and add it to the user's `$PATH`.
* Updated installation instructions to include sections for Antigen, oh-my-zsh and zgen
* Cleaned up some trailing spaces on lines in **README.md**.