### PR TITLE
Fix shell hook status

### DIFF
--- a/desk
+++ b/desk
@@ -73,9 +73,9 @@ cmd_init() {
     echo "# Hook for desk activation" >> "$USER_SHELLRC"
 
     if [ "$SHELLTYPE" == "fish" ]; then
-      echo "test -n \"\$DESK_ENV\"; and . \"\$DESK_ENV\"" >> "$USER_SHELLRC"
+      echo "test -n \"\$DESK_ENV\"; and . \"\$DESK_ENV\"; or true" >> "$USER_SHELLRC"
     else
-      echo "[ -n \"\$DESK_ENV\" ] && source \"\$DESK_ENV\"" >> "$USER_SHELLRC"
+      echo "[ -n \"\$DESK_ENV\" ] && source \"\$DESK_ENV\" || true" >> "$USER_SHELLRC"
     fi
     
     echo "Done. Start adding desks to ${NEW_PREFIX}/desks!"

--- a/desk
+++ b/desk
@@ -74,9 +74,9 @@ cmd_init() {
 
     # Since the hook is appended to the rc file, its exit status becomes
     # the exit status of `source $USER_SHELLRC` which typically
-    # indicates if something went wrong. However, $DESK_ENV being void
-    # causes `test` to set exit status to 1. That, however, is part of
-    # desk's normal operation, so we clear exit status here.
+    # indicates if something went wrong. If $DESK_ENV is void, `test`
+    # sets exit status to 1. That, however, is part of desk's normal
+    # operation, so we clear exit status after that.
     if [ "$SHELLTYPE" == "fish" ]; then
       echo "test -n \"\$DESK_ENV\"; and . \"\$DESK_ENV\"; or true" >> "$USER_SHELLRC"
     else

--- a/desk
+++ b/desk
@@ -74,8 +74,9 @@ cmd_init() {
 
     # Since the hook is appended to the rc file, its exit status becomes
     # the exit status of `source $USER_SHELLRC` which typically
-    # indicates that something went wrong. However, $DESK_ENV being void
-    # shouldn't convey this meaning, so we clear exit status here.
+    # indicates if something went wrong. However, $DESK_ENV being void
+    # causes `test` to set exit status to 1. That, however, is part of
+    # desk's normal operation, so we clear exit status here.
     if [ "$SHELLTYPE" == "fish" ]; then
       echo "test -n \"\$DESK_ENV\"; and . \"\$DESK_ENV\"; or true" >> "$USER_SHELLRC"
     else

--- a/desk
+++ b/desk
@@ -72,6 +72,10 @@ cmd_init() {
 
     echo "# Hook for desk activation" >> "$USER_SHELLRC"
 
+    # Since the hook is appended to the rc file, its exit status becomes
+    # the exit status of `source $USER_SHELLRC` which typically
+    # indicates that something went wrong. However, $DESK_ENV being void
+    # shouldn't convey this meaning, so we clear exit status here.
     if [ "$SHELLTYPE" == "fish" ]; then
       echo "test -n \"\$DESK_ENV\"; and . \"\$DESK_ENV\"; or true" >> "$USER_SHELLRC"
     else


### PR DESCRIPTION
My shell prompt is configured in such a way that it prints status code of the previous command unless it's 0, and since I installed desk I get status code 1 each time I source my shell config.

```
$ . ~/.config/fish/config.fish
> code 1
```

This patch fixes that.