### PR TITLE
Add 'run' command, allow shell args to be forwarded in 'go'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,23 @@ There are no dependencies other than `bash`. Desk is explicitly tested with `bas
 `zsh`, and `fish`.
 
 ```sh
-◲  desk 0.3.1
+◲  desk 0.3.2
 
 Usage:
 
     desk
-        List the current desk and any associated aliases. If no desk
+        List the current desk and any associated aliases. If no desk 
         is being used, display available desks.
     desk init
         Initialize desk configuration.
     desk (list|ls)
         List all desks along with a description.
-    desk (.|go) desk-name
-        Activate a desk.
+    desk (.|go) <desk-name> [shell-args...]
+        Activate a desk. Extra arguments are passed onto shell.
+    desk run <desk-name> <cmd>
+        Run a command within a desk's environment then exit. Think '$SHELL -c'.
     desk edit [desk-name]
-        Edit (or create) a deskfile with the name specified, otherwise
+        Edit (or create) a deskfile with the name specified, otherwise 
         edit the active deskfile.
     desk help
         Show this text.

--- a/desk
+++ b/desk
@@ -8,7 +8,7 @@ DESKS="${DESK_DESKS_DIR:-$PREFIX/desks}"
 ## Commands
 
 cmd_version() {
-    echo "◲  desk 0.3.1"
+    echo "◲  desk 0.3.2"
 }
 
 
@@ -25,8 +25,10 @@ Usage:
         Initialize desk configuration.
     $PROGRAM (list|ls)
         List all desks along with a description.
-    $PROGRAM (.|go) desk-name
-        Activate a desk.
+    $PROGRAM (.|go) <desk-name> [shell-args...]
+        Activate a desk. Extra arguments are passed onto shell.
+    $PROGRAM run <desk-name> <cmd>
+        Run a command within a desk's environment then exit. Think '\$SHELL -c'.
     $PROGRAM edit [desk-name]
         Edit (or create) a deskfile with the name specified, otherwise 
         edit the active deskfile.
@@ -92,13 +94,24 @@ cmd_go() {
     local DESKEXT=$(get_deskfile_extension)
     local DESKPATH="$(find "${DESKS}/" -name "${TODESK}${DESKEXT}")"
 
+    # Shift desk name so we can forward on all arguments to the shell.
+    shift;
+
     if [ -z "$DESKPATH" ]; then 
         echo "Desk $TODESK (${TODESK}${DESKEXT}) not found in $DESKS"
         exit 1
     else
         local SHELL_EXEC="$(get_running_shell)"
-        DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}"
+        DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}" "$@"
     fi
+}
+
+
+cmd_run() {
+    local TODESK="$1"
+    shift;
+    local CMDSTR="$@"
+    cmd_go "$TODESK" -ic "$@"
 }
 
 
@@ -131,7 +144,7 @@ cmd_current() {
         echo "No desk activated." 
         echo ""
         cmd_list
-        exit 2
+        # exit 2
     else
         echo "$DESK_NAME"
         echo_description "$DESKPATH"
@@ -232,6 +245,7 @@ case "$1" in
     version|--version) shift;  cmd_version "$@" ;;
     ls|list) shift;            cmd_list "$@" ;;
     go|.) shift;               cmd_go "$@" ;;
+    run) shift;                cmd_run "$@" ;;
     edit) shift;               cmd_edit "$@" ;;
     *)                         cmd_current "$@" ;;
 esac

--- a/desk
+++ b/desk
@@ -110,7 +110,6 @@ cmd_go() {
 cmd_run() {
     local TODESK="$1"
     shift;
-    local CMDSTR="$@"
     cmd_go "$TODESK" -ic "$@"
 }
 

--- a/examples/desk.sh
+++ b/examples/desk.sh
@@ -9,3 +9,9 @@ alias lint="make lint"
 checkout_pr () {
   git fetch origin pull/$1/head:pr-$1 && git checkout pr-$1;
 }
+
+test() {
+  make lint
+  SHELL_CMD='-c ./run_tests.sh' make bash zsh
+  SHELL_CMD='-c ./run_tests.fish' make fish
+}

--- a/examples/hello.sh
+++ b/examples/hello.sh
@@ -1,0 +1,10 @@
+# Description: simple desk that says hello
+
+
+# Say an informal hello.
+hi() {
+  echo "hi, ${1}!"
+}
+
+# Use if you're from Texas.
+alias howdy="echo howdy there"

--- a/shell_plugins/bash/desk
+++ b/shell_plugins/bash/desk
@@ -9,11 +9,11 @@ _desk() {
 
     case ${COMP_CWORD} in
         1)
-            COMPREPLY=($(compgen -W "edit . go help init list ls version" ${cur}))
+            COMPREPLY=($(compgen -W "edit . go run help init list ls version" ${cur}))
             ;;
         2)
             case ${prev} in
-                edit|go|.)
+                edit|go|.|run)
                     if [[ -d $DESKS ]]; then
                         local desks=$(desk list | cut -d' ' -f1)
                     else

--- a/shell_plugins/zsh/_desk
+++ b/shell_plugins/zsh/_desk
@@ -17,6 +17,7 @@ _subcommands=(
   'edit:Edit or create a desk, defaults to current desk'
   'go:Activate a desk'
   '.:Activate a desk'
+  'run:Run a command within a desk environment'
   'version:Show the desk version.'
 )
 
@@ -26,7 +27,7 @@ if (( CURRENT == 2 )); then
 fi
 
 case "$words[2]" in
-  go|.|edit)
+  go|.|edit|run)
     _all_desks
     _wanted desks expl 'desks' compadd -a desks ;;
 esac

--- a/test/run_tests.fish
+++ b/test/run_tests.fish
@@ -14,7 +14,7 @@ set CURRENT (env DESK_ENV=$HOME/.desk/desks/hello.fish desk)
 echo $CURRENT | grep "say_hello - Args: <hello_to>. Say hello to someone." >/dev/null
 test $status -ne 0; and echo "say_hello command not found"; and exit 1
 
-set RAN (desk run hello mrfish)
+set RAN (desk run hello 'say_hello mrfish')
 echo $RAN | grep "Hello mrfish" >/dev/null
 test $status -ne 0; and echo "Desk run with 'hello' failed"; and exit 1
 

--- a/test/run_tests.fish
+++ b/test/run_tests.fish
@@ -14,4 +14,8 @@ set CURRENT (env DESK_ENV=$HOME/.desk/desks/hello.fish desk)
 echo $CURRENT | grep "say_hello - Args: <hello_to>. Say hello to someone." >/dev/null
 test $status -ne 0; and echo "say_hello command not found"; and exit 1
 
+set RAN (desk run hello mrfish)
+echo $RAN | grep "Hello mrfish" >/dev/null
+test $status -ne 0; and echo "Desk run with 'hello' failed"; and exit 1
+
 exit 0

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -22,6 +22,8 @@ echo $HELP | grep 'desk (list|ls)' >/dev/null
 ensure $? "Desk help doesn't contain list"
 echo $HELP | grep 'desk (.|go)' >/dev/null
 ensure $? "Desk help doesn't contain go"
+echo $HELP | grep 'desk run' >/dev/null
+ensure $? "Desk help doesn't contain run"
 echo $HELP | grep 'desk help' >/dev/null
 ensure $? "Desk help doesn't contain help"
 echo $HELP | grep 'desk version' >/dev/null
@@ -39,6 +41,8 @@ echo $LIST | grep "python_project - desk for working on a Python project" >/dev/
 ensure $? "Desk list missing python_project (with DESK_DESKS_DIR)"
 echo $LIST | grep "terraform - desk for doing work on a terraform-based repository" >/dev/null
 ensure $? "Desk list missing terraform (with DESK_DESKS_DIR)"
+echo $LIST | grep "hello - simple desk that says hello" >/dev/null
+ensure $? "Desk list missing hello (with DESK_DESKS_DIR)"
 
 rm -rf "$HOME/.desk/desks"
 ln -s "$HOME/examples" "$HOME/.desk/desks"
@@ -50,6 +54,8 @@ echo $LIST | grep "python_project - desk for working on a Python project" >/dev/
 ensure $? "Desk list missing python_project (with symlink)"
 echo $LIST | grep "terraform - desk for doing work on a terraform-based repository" >/dev/null
 ensure $? "Desk list missing terraform (with symlink)"
+echo $LIST | grep "hello - simple desk that says hello" >/dev/null
+ensure $? "Desk list missing hello (with symlink)"
 
 mkdir ~/terraform-repo
 
@@ -62,5 +68,13 @@ echo $CURRENT | grep 'apply - Run `terraform apply` with proper AWS var config' 
 ensure $? "Desk current terraform missing apply"
 echo $CURRENT | grep 'config - Set up terraform config: <config_key>' >/dev/null
 ensure $? "Desk current terraform missing config"
+
+RAN=$(desk run hello 'howdy james!')
+echo $RAN | grep 'howdy there james!' >/dev/null
+ensure $? "Run in desk 'hello' didn't work with howdy alias"
+
+RAN=$(desk run hello 'hi j')
+echo $RAN | grep 'hi, j!' >/dev/null
+ensure $? "Run in desk 'hello' didn't work with hi function"
 
 echo "tests pass."


### PR DESCRIPTION
After a few more weeks of use, I've noticed that often I'll invoke a desk just to run a single command, and pop back out immediately afterwards. This PR adds a command called `run` that facilitates that usecase; it's basically an analogue to `$SHELL -c`.

Example usage: 
```sh
 $ desk

No desk activated.

[...]
                                                                                                                                      
 $ desk run puppetry hiera

[puppet] Executing task 'update_hiera'
[puppet] sudo: update-hiera
[puppet] out: Already up-to-date.
[puppet] out: 


Done.
Disconnecting from puppet... done.
                                                                                                                                      
 $ desk

No desk activated.

```

Also in this PR is a change that allows arguments to be forwarded on to the shell process in `.|go`.