### PR TITLE
Fish Shell Completions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ services:
     - docker
 
 before_install:
-    - wget http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-1_amd64.deb
-    - ar x shellcheck_0.3.7-1_amd64.deb 
+    - wget http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-5_amd64.deb
+    - ar x shellcheck_0.3.7-5_amd64.deb 
     - tar xvf data.tar.xz
     - cp ./usr/bin/shellcheck .
 
 env:
     - PATH=$PATH:$(pwd)
 
-script: 
+script:
     - make lint
     - SHELL_CMD='-c ./run_tests.sh' make bash zsh
     - SHELL_CMD='-c ./run_tests.fish' make fish

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are no dependencies other than `bash`. Desk is explicitly tested with `bas
 Usage:
 
     desk
-        List the current desk and any associated aliases. If no desk 
+        List the current desk and any associated aliases. If no desk
         is being used, display available desks.
     desk init
         Initialize desk configuration.
@@ -43,7 +43,7 @@ Usage:
     desk run <desk-name> <cmd>
         Run a command within a desk's environment then exit. Think '$SHELL -c'.
     desk edit [desk-name]
-        Edit (or create) a deskfile with the name specified, otherwise 
+        Edit (or create) a deskfile with the name specified, otherwise
         edit the active deskfile.
     desk help
         Show this text.
@@ -122,13 +122,23 @@ or by manually adding shell scripts into your deskfiles directory (by default `~
 
 ### Enabling shell extensions
 
+**NB**: Shell extensions are automatically enabled if Desk is installed via Homebrew.
+
 #### Using bash
 
 0. Add `source /path/to/desk/repo/shell_plugins/bash/desk` to your `.bashrc`.
 
+#### Using fish
+
+```fish
+mkdir -p ~/.config/fish/completions
+cp /path/to/desk/repo/shell_plugins/fish/desk.fish ~/.config/fish/completions
+```
+
 #### Using zsh
 
 0. Add `fpath=(/path/to/desk/repo/shell_plugins/zsh $fpath)` to your `.zshrc`.
+
 
 Optionally, use one of the zsh plugin frameworks mentioned below.
 
@@ -141,12 +151,12 @@ or
 0. `cd ~/.oh-my-zsh/custom/plugins`
 0. `git clone git@github.com:jamesob/desk.git /tmp/desk && cp -r /tmp/desk/shell_plugins/zsh desk`
 0. Add desk to your plugin list
- 
+
 #### Using [Antigen](https://github.com/zsh-users/antigen)
 
 0. Add `antigen bundle jamesob/desk shell_plugins/zsh` to your `.zshrc`
 0. Open a new terminal window. Antigen will clone the desk repo and add it to your path.
-                                       
+
 #### Using [zgen](https://github.com/tarjoilija/zgen)
 
 0. Add `zgen load jamesob/desk shell_plugins/zsh` to your `.zshrc` with your other load commands

--- a/shell_plugins/fish/desk.fish
+++ b/shell_plugins/fish/desk.fish
@@ -17,16 +17,13 @@ end
 complete -c desk -f -n '__fish_desk_no_subcommand' -a init -d 'Initialize desk configuration'
 
 # desk list|ls
-complete -c desk -f -n '__fish_desk_no_subcommand' -a "ls" -d 'List all desks along with a description'
-complete -c desk -A -f -n '__fish_seen_subcommand_from list' -l only-names -d 'List only the names of the desks'
-complete -c desk -A -f -n '__fish_seen_subcommand_from list' -l no-format -d "Use ' - ' to separate names from descriptions"
-complete -c desk -A -f -n '__fish_seen_subcommand_from ls' -l only-names -d 'List only the names of the desks'
-complete -c desk -A -f -n '__fish_seen_subcommand_from ls' -l no-format -d "Use ' - ' to separate names from descriptions"
+complete -c desk -f -n '__fish_desk_no_subcommand' -a "ls list" -d 'List all desks along with a description'
+complete -c desk -A -f -n '__fish_seen_subcommand_from ls list' -l only-names -d 'List only the names of the desks'
+complete -c desk -A -f -n '__fish_seen_subcommand_from ls list' -l no-format -d "Use ' - ' to separate names from descriptions"
 
 # desk go|.
-complete -c desk -f -n '__fish_desk_no_subcommand' -a "go" -d 'Activate a desk. Extra arguments are passed onto shell'
-complete -c desk -A -f -n '__fish_seen_subcommand_from .' -a "(desk ls --only-names)" -d "Desk"
-complete -c desk -A -f -n '__fish_seen_subcommand_from go' -a "(desk ls --only-names)" -d "Desk"
+complete -c desk -f -n '__fish_desk_no_subcommand' -a "go ." -d 'Activate a desk. Extra arguments are passed onto shell'
+complete -c desk -A -f -n '__fish_seen_subcommand_from . go' -a "(desk ls --only-names)" -d "Desk"
 
 # desk run
 complete -c desk -f -n '__fish_desk_no_subcommand' -a run -d 'Run a command within a desk\'s environment then exit'

--- a/shell_plugins/fish/desk.fish
+++ b/shell_plugins/fish/desk.fish
@@ -1,0 +1,43 @@
+# desk.fish - desk completions for fish shell
+#
+# To install the completions:
+# mkdir -p ~/.config/fish/completions
+# cp desk.fish ~/.config/fish/completions
+
+function __fish_desk_no_subcommand --description 'Test if desk has yet to be given a subcommand'
+    for i in (commandline -opc)
+        if contains -- $i init list ls . go run edit help version
+            return 1
+        end
+    end
+    return 0
+end
+
+# desk
+complete -c desk -f -n '__fish_desk_no_subcommand' -a init -d 'Initialize desk configuration'
+
+# desk list|ls
+complete -c desk -f -n '__fish_desk_no_subcommand' -a "ls" -d 'List all desks along with a description'
+complete -c desk -A -f -n '__fish_seen_subcommand_from list' -l only-names -d 'List only the names of the desks'
+complete -c desk -A -f -n '__fish_seen_subcommand_from list' -l no-format -d "Use ' - ' to separate names from descriptions"
+complete -c desk -A -f -n '__fish_seen_subcommand_from ls' -l only-names -d 'List only the names of the desks'
+complete -c desk -A -f -n '__fish_seen_subcommand_from ls' -l no-format -d "Use ' - ' to separate names from descriptions"
+
+# desk go|.
+complete -c desk -f -n '__fish_desk_no_subcommand' -a "go" -d 'Activate a desk. Extra arguments are passed onto shell'
+complete -c desk -A -f -n '__fish_seen_subcommand_from .' -a "(desk ls --only-names)" -d "Desk"
+complete -c desk -A -f -n '__fish_seen_subcommand_from go' -a "(desk ls --only-names)" -d "Desk"
+
+# desk run
+complete -c desk -f -n '__fish_desk_no_subcommand' -a run -d 'Run a command within a desk\'s environment then exit'
+complete -c desk -A -f -n '__fish_seen_subcommand_from run' -a '(desk ls --only-names)' -d "Desk"
+
+# desk edit
+complete -c desk -f -n '__fish_desk_no_subcommand' -a edit -d 'Edit (or create) a deskfile with the name specified, otherwise edit the active deskfile'
+complete -c desk -A -f -n '__fish_seen_subcommand_from edit' -a '(desk ls --only-names)' -d "Desk"
+
+# desk help
+complete -c desk -f -n '__fish_desk_no_subcommand' -a help -d 'Show help text'
+
+# desk version
+complete -c desk -f -n '__fish_desk_no_subcommand' -a version -d 'Show version information'


### PR DESCRIPTION
This PR adds `desk` completions for the Fish shell. It is based heavily off of [Docker's fish completions](https://github.com/docker/docker/blob/master/contrib/completion/fish/docker.fish).

One note: I am unable to get `.` to show as a suggestion for the sub-command-less `desk` (i.e., `desk<tab>` does not show `.` as an available sub-command; it only shows `go`). I assume this is a limitation of Fish.

If merged, we should also add
```ruby
fish_completion.install "shell_plugins/fish/desk.fish"
```
to the Desk Homebrew package.