### PR TITLE
Accept args in desks (at least in bash and zsh)

### DIFF
--- a/desk
+++ b/desk
@@ -102,7 +102,7 @@ cmd_go() {
         exit 1
     else
         local SHELL_EXEC="$(get_running_shell)"
-        if [ $DESKEXT == '.fish' ]; then
+        if [ "$DESKEXT" == '.fish' ]; then
             DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}" "$@"
         else
             DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}" -s "$@"

--- a/desk
+++ b/desk
@@ -102,7 +102,7 @@ cmd_go() {
         exit 1
     else
         local SHELL_EXEC="$(get_running_shell)"
-        DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}" "$@"
+        DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}" -s "$@"
     fi
 }
 

--- a/desk
+++ b/desk
@@ -102,7 +102,11 @@ cmd_go() {
         exit 1
     else
         local SHELL_EXEC="$(get_running_shell)"
-        DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}" -s "$@"
+        if [ $DESKEXT == '.fish' ]; then
+            DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}" "$@"
+        else
+            DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}" -s "$@"
+        fi
     fi
 }
 


### PR DESCRIPTION
I'd really like to be able to pass arguments to desks.

Currently, `$@` after three shifts is passed directly into the shell executable, meaning that if you do `desk go mydesk some_option`, your shell of choice (as long as you're a reasonable person and not a fish-user) will try and (probably?) fail to run `some_option` as a script. bash and zsh make it easy to change this behavior; I'm not sure about fish but it seems harder in that case (I've tried to sidestep that issue here by leaving the fish executable unchanged).

At least on my machine, this works okay and lets me access shell args in desks.