### PR TITLE
Fixes jamesob/desk#56 adding support for displaying exported environment variables in deskfiles

### DIFF
--- a/desk
+++ b/desk
@@ -185,7 +185,7 @@ cmd_list() {
 
 # Usage:	     desk [options]
 # Description: List the current desk and any associated aliases. If no desk is being used, display available desks
-# --no-format: Use ' - ' to separate alias/function names from their descriptions
+# --no-format: Use ' - ' to separate alias/export/function names from their descriptions
 cmd_current() {
     if [ -z "$DESK_ENV" ]; then
         printf "No desk activated.\n\n%s" "$(cmd_list)"
@@ -214,7 +214,7 @@ cmd_current() {
             (( len > longest )) && longest=$len
             local DOCLINE=$(
                 grep -B 1 -E \
-                    "^(alias ${NAME}=|(function )?${NAME}( )?\()|function $NAME" "$DESKPATH" \
+                    "^(alias ${NAME}=|export ${NAME}=|(function )?${NAME}( )?\()|function $NAME" "$DESKPATH" \
                     | grep "#")
 
             if [ -z "$DOCLINE" ]; then
@@ -262,11 +262,12 @@ echo_description() {
     echo "${descline##*Description: }"
 }
 
-# Echo a list of aliases and functions for a given desk
+# Echo a list of aliases, exports, and functions for a given desk
 get_callables() {
     local DESKPATH=$1
-    grep -E "^(alias |(function )?${FNAME_CHARS}+ ?\()|function $NAME" "$DESKPATH" \
+    grep -E "^(alias |export |(function )?${FNAME_CHARS}+ ?\()|function $NAME" "$DESKPATH" \
         | sed 's/alias \([^= ]*\)=.*/\1/' \
+        | sed 's/export \([^= ]*\)=.*/\1/' \
         | sed -E "s/(function )?(${FNAME_CHARS}+) ?\(\).*/\2/" \
         | sed -E "s/function (${FNAME_CHARS}+).*/\1/"
 }

--- a/examples/hello.sh
+++ b/examples/hello.sh
@@ -9,3 +9,6 @@ hi() {
 # Use if you're from Texas. 
 alias howdy="echo howdy y\'all"
 
+# Why should I always type my name
+export MyName="James"
+

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -122,6 +122,9 @@ echo "$CURRENT" | grep 'config - Set up terraform config: <config_key>' >/dev/nu
 ensure $? "Desk current terraform missing config"
 
 # testing for exported variables
+ISITTHERE=$(less $HOME/.desk/desks/hello.sh)
+echo "$ISITTHERE" | grep -B 1 export
+
 CURRENT=$(DESK_ENV=$HOME/.desk/desks/hello.sh desk)
 echo "$CURRENT" | grep 'MyName     Why should I always type my name' >/dev/null
 ensure $? "Desk current hello missing exported environment variable"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -121,6 +121,12 @@ ensure $? "Desk current terraform missing apply"
 echo "$CURRENT" | grep 'config - Set up terraform config: <config_key>' >/dev/null
 ensure $? "Desk current terraform missing config"
 
+# testing for exported variables
+CURRENT=$(DESK_ENV=$HOME/.desk/desks/hello.sh desk)
+echo "$CURRENT" | grep 'MyName     Why should I always type my name' >/dev/null
+ensure $? "Desk current hello missing exported environment variable"
+
+
 RAN=$(desk run hello 'howdy james!')
 echo "$RAN" | grep 'howdy y'"'"'all james!' >/dev/null
 ensure $? "Run in desk 'hello' didn't work with howdy alias"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -129,6 +129,10 @@ RAN=$(desk run hello 'hi j')
 echo "$RAN" | grep 'hi, j!' >/dev/null
 ensure $? "Run in desk 'hello' didn't work with hi function"
 
+RAN=$(desk run hello 'echo $MyName')
+echo "$RAN" | grep 'James' >/dev/null
+ensure $? "Run in desk 'hello' didn't work with MyName exported variable"
+
 ## `desk go`
 
 RAN=$(desk go example-project/Deskfile -c 'desk ; exit')

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -127,7 +127,7 @@ echo "$ISITTHERE" | grep -B 1 export
 
 CURRENT=$(DESK_ENV=$HOME/.desk/desks/hello.sh desk)
 echo "$CURRENT"
-echo "$CURRENT" | grep 'MyName     Why should I always type my name' >/dev/null
+echo "$CURRENT" | grep 'MyName  Why should I always type my name' >/dev/null
 ensure $? "Desk current hello missing exported environment variable"
 
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -122,11 +122,7 @@ echo "$CURRENT" | grep 'config - Set up terraform config: <config_key>' >/dev/nu
 ensure $? "Desk current terraform missing config"
 
 # testing for exported variables
-ISITTHERE=$(less $HOME/.desk/desks/hello.sh)
-echo "$ISITTHERE" | grep -B 1 export
-
 CURRENT=$(DESK_ENV=$HOME/.desk/desks/hello.sh desk)
-echo "$CURRENT"
 echo "$CURRENT" | grep 'MyName  Why should I always type my name' >/dev/null
 ensure $? "Desk current hello missing exported environment variable"
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -126,6 +126,7 @@ ISITTHERE=$(less $HOME/.desk/desks/hello.sh)
 echo "$ISITTHERE" | grep -B 1 export
 
 CURRENT=$(DESK_ENV=$HOME/.desk/desks/hello.sh desk)
+echo "$CURRENT"
 echo "$CURRENT" | grep 'MyName     Why should I always type my name' >/dev/null
 ensure $? "Desk current hello missing exported environment variable"
 


### PR DESCRIPTION
I've added some working code to display the exported environment variables defined in a desk file as requested in jamesob/desk#56 by @rafaelbco. These code changes do compile and pass tests but that is probably because the tests haven't been increased to include whether this works or not ;-) but I guess the good thing is that it doesn't break anything else. 

Please review and let me know if this is what you would like and I'll work on adding tests for this specific use case. 