### PR TITLE
Use "exec" to start the shell

### DIFF
--- a/desk
+++ b/desk
@@ -130,7 +130,7 @@ cmd_go() {
         exit 1
     else
         local SHELL_EXEC="$(get_running_shell)"
-        DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" "${SHELL_EXEC}" "$@"
+        DESK_NAME="${TODESK}" DESK_ENV="${DESKPATH}" exec "${SHELL_EXEC}" "$@"
     fi
 }
 


### PR DESCRIPTION
By using "exec", the shell instance that is running the `desk` script
is replaced by the new child shell. This will enable the original shell
that invoked `desk` to take care of the child if the user suspends
the child by typing `suspend` inside the desk.