### PR TITLE
fix(whitespace): add a newline before the rc hook

### DIFF
--- a/desk
+++ b/desk
@@ -75,7 +75,7 @@ cmd_init() {
         exit 1
     fi
 
-    echo "# Hook for desk activation" >> "$USER_SHELLRC"
+    echo "\n# Hook for desk activation" >> "$USER_SHELLRC"
 
     # Since the hook is appended to the rc file, its exit status becomes
     # the exit status of `source $USER_SHELLRC` which typically


### PR DESCRIPTION
if the user's rc file is missing a trailing EOL, the hook gets appended to the last line; this added newline fixes that