### PR TITLE
fix new line insertion introduced in #73

### DIFF
--- a/desk
+++ b/desk
@@ -75,7 +75,7 @@ cmd_init() {
         exit 1
     fi
 
-    echo "\n# Hook for desk activation" >> "$USER_SHELLRC"
+    printf "\n# Hook for desk activation\n" >> "$USER_SHELLRC"
 
     # Since the hook is appended to the rc file, its exit status becomes
     # the exit status of `source $USER_SHELLRC` which typically


### PR DESCRIPTION
The change introduced in #73 produces an invalid output (at least on Ubuntu 16.04 LTS) :

![image](https://cloud.githubusercontent.com/assets/576772/21741577/abea57ca-d4da-11e6-9338-d4540337fc77.png)

This happens because `echo` doesn't interpret backslash escapes by default on some distros, it only does so with the `-e` flags, which doesn't have a consistent behavior.
Using `printf` solves that and makes sure that the newline characters are outputed correctly.

ref: http://stackoverflow.com/questions/8467424/echo-newline-in-bash-prints-literal-n/8467449