### PR TITLE
Solution for #81 (Wrong shell interpreter determined.)

### DIFF
--- a/desk
+++ b/desk
@@ -291,7 +291,7 @@ get_running_shell() {
     fi
 
     if [ ! -z "$CMDLINE_SHELL" ]; then
-        if [[ ! $CMDLINE_SHELL = *$SHELL* ]]; then
+        if [ -z $SHELL ] && [[ ! $CMDLINE_SHELL = *$SHELL* ]]; then
             basename "$CMDLINE_SHELL"
             exit
         fi

--- a/desk
+++ b/desk
@@ -291,8 +291,10 @@ get_running_shell() {
     fi
 
     if [ ! -z "$CMDLINE_SHELL" ]; then
-        basename "$CMDLINE_SHELL"
-        exit
+        if [[ ! $CMDLINE_SHELL = *$SHELL* ]]; then
+            basename "$CMDLINE_SHELL"
+            exit
+        fi
     fi
 
     # Fall back to $SHELL otherwise.

--- a/desk
+++ b/desk
@@ -287,14 +287,12 @@ get_running_shell() {
     else
         # Strip leading dash for login shells.
         # If the parent process is a login shell, guess bash.
-        local CMDLINE_SHELL=$(ps -o args -p $PPID | tail -1 | sed -e 's/login/bash/' -e 's/^-//')
+        local CMDLINE_SHELL=$(ps -o comm= -p $PPID | tail -1 | sed -e 's/login/bash/' -e 's/^-//')
     fi
 
     if [ ! -z "$CMDLINE_SHELL" ]; then
-        if [ -z $SHELL ] && [[ ! $CMDLINE_SHELL = *$SHELL* ]]; then
-            basename "$CMDLINE_SHELL"
-            exit
-        fi
+        basename "$CMDLINE_SHELL"
+        exit
     fi
 
     # Fall back to $SHELL otherwise.


### PR DESCRIPTION
Removed the older solution for a new one where the ps command already strips any problematic arguments. Seems to pass the unit tests as well, which is nice. :-)