### PR TITLE
Update url to clone project

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ and add `sudo` as needed.
 
 #### With git
 
-0. `git clone git@github.com:jamesob/desk.git && cd desk && sudo make install`
+0. `git clone https://github.com/jamesob/desk.git && cd desk && sudo make install`
 
 After that, run `desk init` and start adding deskfiles with either `desk edit [deskfile name]`
 or by manually adding shell scripts into your deskfiles directory (by default `~/.desk/desks/`).


### PR DESCRIPTION
With the old url: `git@github.com:jamesob/desk.git` we get a Permission denied error

```
ubuntu@ip-172-31-5-138:~$ git clone git@github.com:jamesob/desk.git
Cloning into 'desk'...
The authenticity of host 'github.com (192.30.253.113)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.253.113' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```