### PR TITLE
Make desk run work with an argument vector.

### DIFF
--- a/desk
+++ b/desk
@@ -30,8 +30,11 @@ Usage:
         Activate a desk. Extra arguments are passed onto shell. If called with
         no arguments, look for a Deskfile in the current directory. If not a
         recognized desk, try as a path to directory containing a Deskfile.
-    $PROGRAM run <desk-name> <cmd>
-        Run a command within a desk's environment then exit. Think '\$SHELL -c'.
+    $PROGRAM run <desk-name> '<cmd>'
+    $PROGRAM run <desk-name> <cmd> <arg>...
+        Run a command within a desk's environment then exit. In the first form
+        shell expansion is performed. In the second form, the argument vector
+        is executed as is.
     $PROGRAM edit [desk-name]
         Edit (or create) a deskfile with the name specified, otherwise
         edit the active deskfile.
@@ -138,7 +141,11 @@ cmd_go() {
 cmd_run() {
     local TODESK="$1"
     shift;
-    cmd_go "$TODESK" -ic "$@"
+    if [ $# -eq 1 ]; then
+        cmd_go "$TODESK" -ic "$1"
+    else
+        cmd_go "$TODESK" -ic '"$@"' -- "$@"
+    fi
 }
 
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -139,6 +139,10 @@ RAN=$(desk run hello 'echo $MyName')
 echo "$RAN" | grep 'James' >/dev/null
 ensure $? "Run in desk 'hello' didn't work with MyName exported variable"
 
+RAN=$(desk run hello echo ahoy matey)
+echo "$RAN" | grep 'ahoy matey' >/dev/null
+ensure $? "Run in desk 'hello' didn't work with argument vector"
+
 ## `desk go`
 
 RAN=$(desk go example-project/Deskfile -c 'desk ; exit')


### PR DESCRIPTION
This change adds a new argument vector form of the `desk run` command, allowing an existing command to be wrapped without requiring quoting/escaping of the command.

In this new form, the argument vector is executed without variable expansion by the shell. This could be supported using `eval`, but it would require some tradeoffs that aren't really worth it IMO (ssh does something like this, and it generally makes a mess of anything but the simplest of commands).

