### PR TITLE
Complete commands following `desk run NAME`.

### DIFF
--- a/shell_plugins/bash/desk
+++ b/shell_plugins/bash/desk
@@ -24,7 +24,7 @@ _desk() {
             esac
             ;;
         *)
-            COMPREPLY=()
+            _command_offset 3
             ;;
     esac
 }


### PR DESCRIPTION
The `_command_offset` function is provided by bash-completion.  I'm not sure if this should assume that environment or offer any alternatives.